### PR TITLE
feature/make key icons configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ OSKD is an on-screen keyboard display that can be used during streams. It provid
 - [X] Make it compatible with multiple platforms.
 - [X] Implement a Shift/CTRL mapper to support key combinations.
 - [X] Make it configurable and customizable.
-- [ ] Allow customization of key icons.
+- [X] Allow customization of key icons.
 - [ ] Implement Keystrokes mode to display all keystrokes on the screen.
 - [ ] Improve security features to ensure privacy and safety.
 - [ ] Explore Joypad compatibility for gamers.

--- a/config.json
+++ b/config.json
@@ -35,6 +35,7 @@
     "fontSize": "1rem",
     "textColor": "#fffa",
     "backgroundColor": "#000c",
-    "borderRadius": "7px"
+    "borderRadius": "7px",
+    "padding": "10px"
   }
 }

--- a/config.json
+++ b/config.json
@@ -30,5 +30,11 @@
     "MetaRight": "⊞",
     "Space": "―",
     "CapsLock": "Caps"
+  },
+  "keyStyle": {
+    "fontSize": "1rem",
+    "textColor": "#fffa",
+    "backgroundColor": "#000c",
+    "borderRadius": "7px"
   }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -10,6 +10,7 @@ let config = {
   },
   modifiersKeys: [],
   keyMapping: {},
+  keyStyle: {},
 };
 
 function setConfig(newConfig) {
@@ -57,6 +58,7 @@ const keys = [];
 function addKey(key) {
   const keyElement = document.createElement("div");
   keyElement.classList.add("key");
+  applyConfigStyling(keyElement);
   keyElement.innerText = key;
   keys.push(keyElement);
   container.appendChild(keyElement);
@@ -66,6 +68,20 @@ function addKey(key) {
   }
 
   return keyElement;
+}
+
+function applyConfigStyling(element) {
+  applyStyleConfig(element, "fontSize");
+  applyStyleConfig(element, "textColor", "color");
+  applyStyleConfig(element, "backgroundColor");
+  applyStyleConfig(element, "borderRadius");
+}
+
+function applyStyleConfig(element, configKey, styleName = configKey) {
+  const cfg = config["keyStyle"][configKey];
+  if (cfg) {
+    element.style[styleName] = cfg;
+  }
 }
 
 function addCombination() {

--- a/public/app.js
+++ b/public/app.js
@@ -75,6 +75,7 @@ function applyConfigStyling(element) {
   applyStyleConfig(element, "textColor", "color");
   applyStyleConfig(element, "backgroundColor");
   applyStyleConfig(element, "borderRadius");
+  applyStyleConfig(element, "padding");
 }
 
 function applyStyleConfig(element, configKey, styleName = configKey) {

--- a/public/default_config.json
+++ b/public/default_config.json
@@ -35,6 +35,7 @@
     "fontSize": "1rem",
     "textColor": "#fffa",
     "backgroundColor": "#000c",
-    "borderRadius": "7px"
+    "borderRadius": "7px",
+    "padding": "10px"
   }
 }

--- a/public/default_config.json
+++ b/public/default_config.json
@@ -30,5 +30,11 @@
     "MetaRight": "⊞",
     "Space": "―",
     "CapsLock": "Caps"
+  },
+  "keyStyle": {
+    "fontSize": "1rem",
+    "textColor": "#fffa",
+    "backgroundColor": "#000c",
+    "borderRadius": "7px"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -53,8 +53,8 @@
       }
 
       .key:last-child {
-        background-color: #000;
-        color: #eb74dd;
+        background-color: #000 !important;
+        color: #eb74dd !important;
       }
     </style>
   </body>


### PR DESCRIPTION
This adds the ability to configure the look of the key icons via the config.json.
To achieve this, the following config options have been added:

```json
"keyStyle": {
    "fontSize": "1rem",
    "textColor": "#fffa",
    "backgroundColor": "#000c",
    "borderRadius": "7px",
    "padding": "10px"
}
```

Let me know if you have any improvements I should apply.